### PR TITLE
Add step to list available artifacts in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,13 @@ jobs:
             echo "build_id=main-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           fi
 
+      - name: List available artifacts
+        run: |
+          echo "Available artifacts from build workflow:"
+          gh api "/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq '.artifacts[] | .name'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Download the specific build artifact we want to release
       - name: Download build artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This step fetches and displays the artifacts from the triggering workflow run using GitHub API and `jq`. It helps in identifying the available artifacts before proceeding with the download step.