### PR TITLE
fix : Update release workflow to upload only files as assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.semantic-release.outputs.new_version || 'v0.0.0' }}
         run: |
-          gh release create "$NEW_VERSION" \
-            --title "Release $NEW_VERSION" \
-            --generate-notes \
-            ./dist/**/*
+          # Create the release first
+          gh release create "$NEW_VERSION" --title "Release $NEW_VERSION" --generate-notes
+
+          # Then upload files (not directories) as assets
+          find ./dist -type f -exec gh release upload "$NEW_VERSION" {} \;
 
       - name: npm publish
         run: npm run publish


### PR DESCRIPTION
Changed the release process to create the release first and then upload individual files from the `dist` directory as assets. This ensures only valid files are included while avoiding directories.